### PR TITLE
[Feature] 화면 공유 트랙을 썸네일 뷰 최좌측에 자동 배치 (#224)

### DIFF
--- a/apps/client/src/features/video-thumbnail/ui/ParticipantTile.tsx
+++ b/apps/client/src/features/video-thumbnail/ui/ParticipantTile.tsx
@@ -1,38 +1,44 @@
 import { Participant, Track } from "livekit-client";
 
-import { VideoTrack, useIsSpeaking } from "@livekit/components-react";
+import { type TrackReference, VideoTrack, useIsSpeaking } from "@livekit/components-react";
 
 interface ParticipantTileProps {
-  participant: Participant;
+  participant?: Participant;
+  trackRef?: TrackReference;
 }
 
-const ParticipantTile = ({ participant }: ParticipantTileProps) => {
-  const isSpeaking = useIsSpeaking(participant);
-  const cameraTrack = participant.getTrackPublication(Track.Source.Camera);
-  const hasVideo = cameraTrack?.track && !cameraTrack.isMuted;
+const ParticipantTile = ({ participant, trackRef }: ParticipantTileProps) => {
+  const isScreenShare = !!trackRef;
+  const targetParticipant = trackRef?.participant ?? participant;
+  const isSpeaking = useIsSpeaking(targetParticipant);
+
+  if (!targetParticipant) return null;
+
+  const publication = isScreenShare
+    ? trackRef?.publication
+    : targetParticipant.getTrackPublication(Track.Source.Camera);
+  const hasVideo = publication?.track && !publication.isMuted;
+
+  const videoTrackRef = isScreenShare
+    ? trackRef
+    : { participant: targetParticipant, source: Track.Source.Camera, publication: publication! };
 
   return (
     <div
       className={`relative h-24 w-32 shrink-0 overflow-hidden rounded-lg bg-gray-800 ${
-        isSpeaking ? "ring-2 ring-green-500" : ""
-      }`}
+        isScreenShare ? "ring-2 ring-blue-500" : ""
+      } ${isSpeaking ? "ring-2 ring-green-500" : ""}`}
     >
-      {hasVideo ? (
-        <VideoTrack
-          trackRef={{
-            participant,
-            source: Track.Source.Camera,
-            publication: cameraTrack,
-          }}
-          className="h-full w-full object-cover"
-        />
+      {hasVideo && publication ? (
+        <VideoTrack trackRef={videoTrackRef} className="h-full w-full object-cover" />
       ) : (
         <div className="flex h-full w-full items-center justify-center text-2xl text-white">
-          {participant.name?.charAt(0) || participant.identity.charAt(0)}
+          {targetParticipant.name?.charAt(0) || targetParticipant.identity.charAt(0)}
         </div>
       )}
       <div className="absolute bottom-1 left-1 rounded bg-black/50 px-1 text-xs text-white">
-        {participant.name || participant.identity}
+        {isScreenShare ? "🖥️ " : ""}
+        {targetParticipant.name || targetParticipant.identity}
       </div>
     </div>
   );

--- a/apps/client/src/features/video-thumbnail/ui/VideoThumbnailList.tsx
+++ b/apps/client/src/features/video-thumbnail/ui/VideoThumbnailList.tsx
@@ -1,27 +1,29 @@
 import ParticipantTile from "./ParticipantTile";
+import { Track } from "livekit-client";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
-import { useParticipants } from "@livekit/components-react";
+import { useParticipants, useTracks } from "@livekit/components-react";
 import { ICON_SIZE } from "@shared/config";
 import { useResponsiveVisibility, useScrollableContainer, useVisibleUsers } from "@shared/model";
 
 const VideoThumbnailList = () => {
+  const screenShareTracks = useTracks([Track.Source.ScreenShare]);
   const participants = useParticipants();
   const visibleUserIds = useVisibleUsers();
-
   const visibleParticipants = visibleUserIds
     ? participants.filter((p) => visibleUserIds.has(p.identity))
     : participants;
 
-  const { scrollContainerRef, canScrollLeft, canScrollRight, checkScrollability, scroll } = useScrollableContainer(
-    visibleParticipants.length,
-  );
+  const totalItemCount = screenShareTracks.length + visibleParticipants.length;
+
+  const { scrollContainerRef, canScrollLeft, canScrollRight, checkScrollability, scroll } =
+    useScrollableContainer(totalItemCount);
 
   const { getResponsiveClass, MAXIMUM_NUMBER_OF_VISUAL_MEMBERS } = useResponsiveVisibility();
 
-  if (visibleParticipants.length === 0) return null;
+  if (totalItemCount === 0) return null;
 
-  const isScrollable = visibleParticipants.length > MAXIMUM_NUMBER_OF_VISUAL_MEMBERS;
+  const isScrollable = totalItemCount > MAXIMUM_NUMBER_OF_VISUAL_MEMBERS;
 
   return (
     <div className="flex items-center gap-1">
@@ -43,8 +45,13 @@ const VideoThumbnailList = () => {
         }`}
         style={isScrollable ? { scrollbarWidth: "none", msOverflowStyle: "none" } : undefined}
       >
+        {screenShareTracks.map((track, index) => (
+          <div key={`${track.participant.sid}-screen`} className={getResponsiveClass(index)}>
+            <ParticipantTile trackRef={track} />
+          </div>
+        ))}
         {visibleParticipants.map((participant, index) => (
-          <div key={participant.sid} className={getResponsiveClass(index)}>
+          <div key={participant.sid} className={getResponsiveClass(index + screenShareTracks.length)}>
             <ParticipantTile participant={participant} />
           </div>
         ))}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #224 

<br />

## 📝 작업 내용

- 화면 공유가 시작되면 해당 트랙을 썸네일 목록 최좌측에 노출하도록 개선
- 카메라 트랙과 화면 공유 트랙을 동일한 ParticipantTile 구조로 처리하도록 로직 정리
- trackRef 기반으로 participant / publication을 분기 처리
- VideoThumbnailList에서 화살표 노출 여부 계산 시 screenShareTracks도 함께 계산

https://github.com/user-attachments/assets/5b0fcf40-c2b0-4c86-a964-78b9e133e681


<br />

## 🫡 참고사항
> 리뷰 예상 시간: `5분`
- 첨부된 영상은 네트워크 이슈로 인해 중간에 일부 끊김이 발생했습니다. 동작 확인 시 참고 부탁드립니다.