### PR TITLE
[Bugfix] 스톱워치 정지 시 초기화 문제 해결 (#240)

### DIFF
--- a/apps/client/src/features/timer-stopwatch-sidebar/model/use-stopwatch.ts
+++ b/apps/client/src/features/timer-stopwatch-sidebar/model/use-stopwatch.ts
@@ -36,9 +36,8 @@ export const useStopwatch = (): UseStopwatchReturn => {
       if (intervalRef.current !== null) {
         clearInterval(intervalRef.current);
       }
-      resetStopwatch();
     };
-  }, [isRunning, resetStopwatch]);
+  }, [isRunning]);
 
   const start = useCallback(() => {
     setStopwatch({ startedAt: Date.now(), isRunning: true });


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close #240

<br />

## 📝 작업 내용

- 정지할 때 cleanup이 실행되면서 resetStopwatch()가 호출되어 0으로 초기화되는 문제
- resetStopwatch() 제거하여 해결

https://github.com/user-attachments/assets/66f7d8af-2a5b-4b3d-bd20-5e855b1e340c


<br />

## 🫡 참고사항
> 리뷰 예상 시간: `1분`