### PR TITLE
[Refactor] 이미지 수정 시 webp 확장자 변환 (#269) 

### DIFF
--- a/apps/client/src/features/restaurant-sidebar/ui/ImageViewerModal.tsx
+++ b/apps/client/src/features/restaurant-sidebar/ui/ImageViewerModal.tsx
@@ -10,6 +10,7 @@ import { useUserStore } from "@entities/user";
 import { ICON_SIZE, SIDEBAR_TAB_WIDTH, SIDEBAR_WIDTH } from "@shared/config";
 import { useSidebarStore } from "@widgets/sidebar";
 
+import { optimizeImage } from "../lib/optimize-image";
 import { INVALID_SIZE_MESSAGE, INVALID_TYPE_MESSAGE } from "../model/message.constants";
 import { DEFAULT_ACCEPT, validateImageFile } from "../model/use-image-attachment";
 import { Pencil, Trash2, X } from "lucide-react";
@@ -88,8 +89,10 @@ const ImageViewerModal = ({ onDelete, onUpdate }: ImageViewerModalProps) => {
       }
 
       setIsUpdating(true);
+      const optimizedFile = await optimizeImage(file);
+
       try {
-        const newUrl = await replaceMutation.mutateAsync({ imageUrl, file });
+        const newUrl = await replaceMutation.mutateAsync({ imageUrl, file: optimizedFile });
         onUpdate(imageUrl, newUrl);
         closeViewer();
       } catch {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close #269

<br />

## 📝 작업 내용

- 이미지 뷰어에서 이미지를 교체할 때 원본 파일을 전달하고 있어 수정 시에도 `optimizeImage`를 호출하도록 함
<img width="767" height="57" alt="image" src="https://github.com/user-attachments/assets/2ddabe34-96b4-401f-864d-4bb788c69e51" />
- 코드 수정 전
<img width="770" height="54" alt="image" src="https://github.com/user-attachments/assets/968fecdf-d5c6-4678-a5e9-ee6915121eb2" />
- 코드 수정 후
<br />

## 🫡 참고사항
> 리뷰 예상 시간: `1분`