### PR TITLE
[HotFix] EasyStar 동적 import 방식 수정으로 번들 오류 해결 (#280)

### DIFF
--- a/apps/client/src/features/game/managers/auto-move.manager.ts
+++ b/apps/client/src/features/game/managers/auto-move.manager.ts
@@ -4,7 +4,7 @@ import type { GameScene } from "../core";
 import { AUTO_MOVE_BLOCKED, AUTO_MOVE_DURATION } from "../model/game.constants";
 import type { TilePoint } from "../model/game.types";
 import { getDirBetween, tileToWorld, worldToTile } from "../utils";
-import type * as EasyStar from "easystarjs";
+import type EasyStar from "easystarjs";
 
 export class AutoMoveManager {
   private scene: GameScene;
@@ -62,7 +62,7 @@ export class AutoMoveManager {
     const map = this.scene.mapInfo.map;
     if (!map) return;
 
-    const EasyStar = await import("easystarjs");
+    const EasyStar = (await import("easystarjs")).default;
     this.easystar = new EasyStar.js();
 
     const grid: number[][] = Array.from({ length: map.height }, () => Array(map.width).fill(0));

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -23,7 +23,6 @@ export default defineConfig({
           if (!id.includes("node_modules")) return;
 
           if (id.includes("phaser")) return "phaser";
-          if (id.includes("easystarjs")) return "easystarjs";
           if (id.includes("@livekit/krisp-noise-filter")) return "livekit-krisp";
           if (id.includes("@livekit/components-react")) return "livekit-component";
           if (id.includes("livekit-client")) return "livekit-client";


### PR DESCRIPTION
## 📝 작업 내용

- EasyStar 모듈 동적 임포트 방식 되돌리기
- vite 빌드 청크에서 easystarjs 제거

<br />

## 🫡 참고사항
> 리뷰 예상 시간: `1분`

https://boostcampwm10-me.slack.com/archives/C0A1NPYP2K1/p1772017097539879

### 요약
- easystarjs는 별도 청크로 분리되지 않고 vendor 청크에 포함됨
- vendor 청크에는 여러 라이브러리가 함께 묶임
- Rollup이 이 혼합 청크를 CJS 호환 방식으로 번들링함
- 그래서 easystarjs가 단독 ESM 청크로 변환되지 않음
