### PR TITLE
[Refactor] Knock 수락 상태 재검증 및 키 구분자 수정(#284)

### DIFF
--- a/apps/client/src/entities/knock/model/knock.store.ts
+++ b/apps/client/src/entities/knock/model/knock.store.ts
@@ -6,11 +6,13 @@ interface KnockState {
   receivedKnocks: Knock[];
   sentKnockTargets: string[];
   knockFailedMessage: string | null;
+  pendingAcceptSocketId: string | null;
   addReceivedKnock: (knock: Knock) => void;
   removeReceivedKnock: (fromSocketId: string) => void;
   addSentKnock: (targetSocketId: string) => void;
   removeSentKnock: (targetSocketId: string) => void;
   setKnockFailedMessage: (message: string | null) => void;
+  setPendingAcceptSocketId: (socketId: string | null) => void;
   clearAllKnocks: () => void;
 }
 
@@ -18,6 +20,7 @@ export const useKnockStore = create<KnockState>((set) => ({
   receivedKnocks: [],
   sentKnockTargets: [],
   knockFailedMessage: null,
+  pendingAcceptSocketId: null,
 
   addReceivedKnock: (knock) =>
     set((state) => {
@@ -45,6 +48,8 @@ export const useKnockStore = create<KnockState>((set) => ({
     })),
 
   setKnockFailedMessage: (message) => set({ knockFailedMessage: message }),
+
+  setPendingAcceptSocketId: (socketId) => set({ pendingAcceptSocketId: socketId }),
 
   clearAllKnocks: () =>
     set({

--- a/apps/client/src/features/desk-zone-sidebar/ui/DeskZoneSidebar.tsx
+++ b/apps/client/src/features/desk-zone-sidebar/ui/DeskZoneSidebar.tsx
@@ -20,11 +20,11 @@ const DeskZoneSidebar = () => {
   const receivedKnocks = useKnockStore((s) => s.receivedKnocks);
   const knockFailedMessage = useKnockStore((s) => s.knockFailedMessage);
   const setKnockFailedMessage = useKnockStore((s) => s.setKnockFailedMessage);
+  const setPendingAcceptSocketId = useKnockStore((s) => s.setPendingAcceptSocketId);
 
   const { sendKnock, acceptKnock, rejectKnock, updateDeskStatus, canKnockTo, endTalk, isTalking } = useKnock();
 
   const [showEndTalkConfirm, setShowEndTalkConfirm] = useState(false);
-  const [pendingAcceptSocketId, setPendingAcceptSocketId] = useState<string | null>(null);
   const [selectedSocketId, setSelectedSocketId] = useState<string | null>(null);
 
   const deskZoneUsers = users.filter((u) => u.avatar.currentRoomId === "desk zone");
@@ -57,12 +57,6 @@ const DeskZoneSidebar = () => {
 
   const handleConfirmEndAndAccept = () => {
     endTalk();
-    if (pendingAcceptSocketId) {
-      setTimeout(() => {
-        acceptKnock(pendingAcceptSocketId);
-        setPendingAcceptSocketId(null);
-      }, 100);
-    }
     setShowEndTalkConfirm(false);
   };
 

--- a/apps/client/src/features/knock/model/use-knock-socket.ts
+++ b/apps/client/src/features/knock/model/use-knock-socket.ts
@@ -20,6 +20,8 @@ export const useKnockSocket = () => {
   const removeReceivedKnock = useKnockStore((s) => s.removeReceivedKnock);
   const removeSentKnock = useKnockStore((s) => s.removeSentKnock);
   const setKnockFailedMessage = useKnockStore((s) => s.setKnockFailedMessage);
+  const pendingAcceptSocketId = useKnockStore((s) => s.pendingAcceptSocketId);
+  const setPendingAcceptSocketId = useKnockStore((s) => s.setPendingAcceptSocketId);
   const updateUserDeskStatus = useUserStore((s) => s.updateUserDeskStatus);
   const addSidebarKey = useSidebarStore((s) => s.addKey);
   const removeSidebarKey = useSidebarStore((s) => s.removeKey);
@@ -51,6 +53,10 @@ export const useKnockSocket = () => {
 
     const handleTalkEnded = () => {
       removeSidebarKey("chat");
+      if (pendingAcceptSocketId) {
+        socket.emit(KnockEventType.KNOCK_ACCEPT, { fromSocketId: pendingAcceptSocketId });
+        setPendingAcceptSocketId(null);
+      }
     };
 
     const handleKnockCancelled = (payload: KnockCancelledPayload) => {
@@ -101,5 +107,7 @@ export const useKnockSocket = () => {
     updateUserDeskStatus,
     addSidebarKey,
     removeSidebarKey,
+    pendingAcceptSocketId,
+    setPendingAcceptSocketId,
   ]);
 };

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -101,6 +101,9 @@
       "src/**/*.(t|j)s"
     ],
     "coverageDirectory": "coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/src/$1"
+    }
   }
 }

--- a/apps/server/src/knock/knock.gateway.ts
+++ b/apps/server/src/knock/knock.gateway.ts
@@ -89,6 +89,10 @@ export class KnockGateway {
         fromSocketId: payload.fromSocketId,
         reason: "현재 노크를 수락할 수 없는 상태입니다.",
       });
+      this.knockService.removePendingKnock(payload.fromSocketId, client.id);
+      this.server.to(payload.fromSocketId).emit(KnockEventType.KNOCK_CANCELLED, {
+        targetSocketId: client.id,
+      });
       return;
     }
 

--- a/apps/server/src/knock/knock.gateway.ts
+++ b/apps/server/src/knock/knock.gateway.ts
@@ -84,12 +84,23 @@ export class KnockGateway {
       return;
     }
 
+    if (toUser.deskStatus === "talking") {
+      client.emit(KnockEventType.KNOCK_ACCEPT_FAILED, {
+        fromSocketId: payload.fromSocketId,
+        reason: "현재 노크를 수락할 수 없는 상태입니다.",
+      });
+      return;
+    }
+
     if (fromUser.deskStatus === "talking") {
       client.emit(KnockEventType.KNOCK_ACCEPT_FAILED, {
         fromSocketId: payload.fromSocketId,
         reason: "상대방이 이미 다른 대화 중입니다.",
       });
       this.knockService.removePendingKnock(payload.fromSocketId, client.id);
+      this.server.to(payload.fromSocketId).emit(KnockEventType.KNOCK_CANCELLED, {
+        targetSocketId: client.id,
+      });
       return;
     }
 
@@ -99,6 +110,9 @@ export class KnockGateway {
         reason: "상대방이 집중 모드 상태입니다.",
       });
       this.knockService.removePendingKnock(payload.fromSocketId, client.id);
+      this.server.to(payload.fromSocketId).emit(KnockEventType.KNOCK_CANCELLED, {
+        targetSocketId: client.id,
+      });
       return;
     }
 

--- a/apps/server/src/knock/knock.gateway.ts
+++ b/apps/server/src/knock/knock.gateway.ts
@@ -131,7 +131,7 @@ export class KnockGateway {
 
     this.knockService.addTalkingPair(client.id, payload.fromSocketId);
 
-    const contactId = [client.id, payload.fromSocketId].sort().join("-");
+    const contactId = [client.id, payload.fromSocketId].sort().join("|");
     this.userService.updateSessionContactId(client.id, contactId);
     this.userService.updateSessionContactId(payload.fromSocketId, contactId);
 

--- a/apps/server/src/knock/knock.service.ts
+++ b/apps/server/src/knock/knock.service.ts
@@ -8,7 +8,7 @@ export class KnockService {
   private talkingPairs = new Map<string, string>();
 
   private getKnockKey(fromSocketId: string, toSocketId: string): string {
-    return `${fromSocketId}-${toSocketId}`;
+    return `${fromSocketId}|${toSocketId}`;
   }
 
   canKnock(fromStatus: DeskStatus | null, toStatus: DeskStatus | null): { canKnock: boolean; reason?: string } {
@@ -55,7 +55,7 @@ export class KnockService {
     const receivedFrom: string[] = [];
 
     for (const [key] of this.pendingKnocks) {
-      const [fromId, toId] = key.split("-");
+      const [fromId, toId] = key.split("|");
       if (fromId === socketId) {
         sentTo.push(toId);
         this.pendingKnocks.delete(key);

--- a/apps/server/test/knock/knock.gateway.spec.ts
+++ b/apps/server/test/knock/knock.gateway.spec.ts
@@ -1,0 +1,315 @@
+import { KnockEventType } from "@shared/types";
+import type { User } from "@shared/types";
+import "reflect-metadata";
+import type { Socket } from "socket.io";
+
+import { KnockGateway } from "../../src/knock/knock.gateway";
+import { KnockService } from "../../src/knock/knock.service";
+import { type UserService } from "../../src/user/user.service";
+
+jest.mock("../../src/user/user.service");
+
+function createUserSession(socketId: string, deskStatus: "available" | "focusing" | "talking" | null): User {
+  return {
+    socketId,
+    userId: 1,
+    contactId: null,
+    nickname: `User_${socketId}`,
+    cameraOn: false,
+    micOn: false,
+    avatar: {
+      x: 0,
+      y: 0,
+      currentRoomId: "desk zone",
+      direction: "down",
+      state: "idle",
+      assetKey: "ADAM",
+    },
+    deskStatus,
+  };
+}
+
+function createMockSocket(socketId: string): Socket {
+  return { id: socketId, emit: jest.fn() } as unknown as Socket;
+}
+
+function createMockServer() {
+  const emit = jest.fn();
+  const to = jest.fn().mockReturnValue({ emit });
+  return { to, emit, _childEmit: emit };
+}
+
+describe("KnockGateway", () => {
+  let gateway: KnockGateway;
+  let knockService: KnockService;
+  let mockUserService: jest.Mocked<
+    Pick<UserService, "getSession" | "updateSessionDeskStatus" | "updateSessionContactId">
+  >;
+  let mockServer: ReturnType<typeof createMockServer>;
+
+  beforeEach(() => {
+    knockService = new KnockService();
+
+    mockUserService = {
+      getSession: jest.fn(),
+      updateSessionDeskStatus: jest.fn().mockReturnValue(true),
+      updateSessionContactId: jest.fn().mockReturnValue(true),
+    };
+
+    mockServer = createMockServer();
+
+    gateway = new KnockGateway(knockService, mockUserService as unknown as UserService);
+    (gateway as unknown as { server: typeof mockServer }).server = mockServer;
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe("handleKnockAccept - 정상 흐름", () => {
+    it("A→B 수락 성공: talkingPair 등록, KNOCK_ACCEPT_SUCCESS 전송", () => {
+      const userA = createUserSession("A", "available");
+      const userB = createUserSession("B", "available");
+      mockUserService.getSession.mockImplementation(
+        (id) => (({ A: userA, B: userB }) as Partial<Record<string, User>>)[id],
+      );
+      knockService.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+
+      const clientB = createMockSocket("B");
+      gateway.handleKnockAccept(clientB, { fromSocketId: "A" });
+
+      expect(clientB.emit).toHaveBeenCalledWith(
+        KnockEventType.KNOCK_ACCEPT_SUCCESS,
+        expect.objectContaining({ fromSocketId: "A" }),
+      );
+      expect(knockService.getTalkingPartner("B")).toBe("A");
+      expect(knockService.getTalkingPartner("A")).toBe("B");
+    });
+
+    it("수락 후 pending knock 삭제됨", () => {
+      const userA = createUserSession("A", "available");
+      const userB = createUserSession("B", "available");
+      mockUserService.getSession.mockImplementation(
+        (id) => (({ A: userA, B: userB }) as Partial<Record<string, User>>)[id],
+      );
+      knockService.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+
+      gateway.handleKnockAccept(createMockSocket("B"), { fromSocketId: "A" });
+
+      expect(knockService.hasPendingKnock("A", "B")).toBe(false);
+    });
+  });
+
+  describe("handleKnockAccept - 발신자(fromUser) 상태 검증", () => {
+    it("fromUser talking → KNOCK_ACCEPT_FAILED", () => {
+      const userA = createUserSession("A", "talking");
+      const userB = createUserSession("B", "available");
+      mockUserService.getSession.mockImplementation(
+        (id) => (({ A: userA, B: userB }) as Partial<Record<string, User>>)[id],
+      );
+      knockService.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+
+      const clientB = createMockSocket("B");
+      gateway.handleKnockAccept(clientB, { fromSocketId: "A" });
+
+      expect(clientB.emit).toHaveBeenCalledWith(
+        KnockEventType.KNOCK_ACCEPT_FAILED,
+        expect.objectContaining({ reason: expect.stringContaining("다른 대화") }),
+      );
+    });
+
+    it("fromUser focusing → KNOCK_ACCEPT_FAILED", () => {
+      const userA = createUserSession("A", "focusing");
+      const userB = createUserSession("B", "available");
+      mockUserService.getSession.mockImplementation(
+        (id) => (({ A: userA, B: userB }) as Partial<Record<string, User>>)[id],
+      );
+      knockService.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+
+      const clientB = createMockSocket("B");
+      gateway.handleKnockAccept(clientB, { fromSocketId: "A" });
+
+      expect(clientB.emit).toHaveBeenCalledWith(KnockEventType.KNOCK_ACCEPT_FAILED, expect.any(Object));
+    });
+
+    it("pending knock 없음 → KNOCK_ACCEPT_FAILED", () => {
+      const userA = createUserSession("A", "available");
+      const userB = createUserSession("B", "available");
+      mockUserService.getSession.mockImplementation(
+        (id) => (({ A: userA, B: userB }) as Partial<Record<string, User>>)[id],
+      );
+
+      const clientB = createMockSocket("B");
+      gateway.handleKnockAccept(clientB, { fromSocketId: "A" });
+
+      expect(clientB.emit).toHaveBeenCalledWith(
+        KnockEventType.KNOCK_ACCEPT_FAILED,
+        expect.objectContaining({ reason: expect.stringContaining("찾을 수 없습니다") }),
+      );
+    });
+
+    it("fromUser 접속 해제됨(undefined) → KNOCK_ACCEPT_FAILED", () => {
+      const userB = createUserSession("B", "available");
+      mockUserService.getSession.mockImplementation((id) => {
+        if (id === "A") return undefined;
+        if (id === "B") return userB;
+      });
+
+      const clientB = createMockSocket("B");
+      gateway.handleKnockAccept(clientB, { fromSocketId: "A" });
+
+      expect(clientB.emit).toHaveBeenCalledWith(KnockEventType.KNOCK_ACCEPT_FAILED, expect.any(Object));
+    });
+  });
+
+  // ===========================================================
+  // [Bug-1] toUser(수락자) 상태 미검증 재현
+  //
+  // knock.gateway.ts:65-148 handleKnockAccept에서
+  // fromUser의 상태(line 87, 96)는 재검증하지만
+  // toUser(client 본인)의 현재 상태는 재검증하지 않음.
+  //
+  // 시나리오:
+  //   t=1: B가 C의 노크를 수락 → B: talking, C: talking
+  //   t=2: B(이미 talking)가 A의 노크도 수락 시도
+  //
+  // 기대: KNOCK_ACCEPT_FAILED (B가 이미 talking)
+  // 실제: 수락 성공 → B-A talkingPair 등록 (B-C 덮어씌워짐)
+  //
+  // → 이 테스트는 버그가 수정될 때까지 실패(FAIL)해야 함
+  // ===========================================================
+  describe("[Bug-1] toUser(수락자) 상태 미검증 재현", () => {
+    it("[버그 재현] talking 상태인 B가 또 다른 노크를 수락하면 막혀야 하지만 통과됨", () => {
+      const userA = createUserSession("A", "available");
+      const userB = createUserSession("B", "talking");
+      const userC = createUserSession("C", "talking");
+
+      mockUserService.getSession.mockImplementation(
+        (id) => (({ A: userA, B: userB, C: userC }) as Partial<Record<string, User>>)[id],
+      );
+      knockService.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+      knockService.addTalkingPair("B", "C");
+
+      const clientB = createMockSocket("B");
+      gateway.handleKnockAccept(clientB, { fromSocketId: "A" });
+
+      expect(clientB.emit).toHaveBeenCalledWith(
+        KnockEventType.KNOCK_ACCEPT_FAILED,
+        expect.objectContaining({ reason: expect.any(String) }),
+      );
+      expect(knockService.getTalkingPartner("A")).toBeUndefined();
+    });
+
+    it("[버그 결과] talkingPairs 상태 오염 확인: B-C 덮어씌워져 C가 방치됨", () => {
+      const userA = createUserSession("A", "available");
+      const userB = createUserSession("B", "talking");
+      const userC = createUserSession("C", "talking");
+
+      mockUserService.getSession.mockImplementation(
+        (id) => (({ A: userA, B: userB, C: userC }) as Partial<Record<string, User>>)[id],
+      );
+      knockService.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+      knockService.addTalkingPair("B", "C");
+
+      gateway.handleKnockAccept(createMockSocket("B"), { fromSocketId: "A" });
+
+      const bPartner = knockService.getTalkingPartner("B");
+      const cPartner = knockService.getTalkingPartner("C");
+
+      if (bPartner === "A") {
+        expect(cPartner).toBe("B");
+      }
+    });
+  });
+
+  describe("handleKnockAccept - 교차 노크 정리", () => {
+    it("A→B와 B→A 교차 노크 시 B가 A 수락 → B→A 역방향 knock 정리됨", () => {
+      const userA = createUserSession("A", "available");
+      const userB = createUserSession("B", "available");
+      mockUserService.getSession.mockImplementation(
+        (id) => (({ A: userA, B: userB }) as Partial<Record<string, User>>)[id],
+      );
+      knockService.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+      knockService.addPendingKnock({ fromSocketId: "B", fromUserNickname: "B", timestamp: 1 }, "A");
+
+      gateway.handleKnockAccept(createMockSocket("B"), { fromSocketId: "A" });
+
+      expect(knockService.hasPendingKnock("B", "A")).toBe(false);
+    });
+  });
+
+  describe("handleKnockSend", () => {
+    it("양쪽 available → 노크 등록, 수신자에게 KNOCK_RECEIVED 전송", () => {
+      const userA = createUserSession("A", "available");
+      const userB = createUserSession("B", "available");
+      mockUserService.getSession.mockImplementation(
+        (id) => (({ A: userA, B: userB }) as Partial<Record<string, User>>)[id],
+      );
+
+      gateway.handleKnockSend(createMockSocket("A"), { targetSocketId: "B" });
+
+      expect(knockService.hasPendingKnock("A", "B")).toBe(true);
+      expect(mockServer.to).toHaveBeenCalledWith("B");
+    });
+
+    it("발신자 focusing → error, knock 등록 안됨", () => {
+      const userA = createUserSession("A", "focusing");
+      const userB = createUserSession("B", "available");
+      mockUserService.getSession.mockImplementation(
+        (id) => (({ A: userA, B: userB }) as Partial<Record<string, User>>)[id],
+      );
+
+      const clientA = createMockSocket("A");
+      gateway.handleKnockSend(clientA, { targetSocketId: "B" });
+
+      expect(clientA.emit).toHaveBeenCalledWith("error", expect.any(Object));
+      expect(knockService.hasPendingKnock("A", "B")).toBe(false);
+    });
+
+    it("중복 노크 → error", () => {
+      const userA = createUserSession("A", "available");
+      const userB = createUserSession("B", "available");
+      mockUserService.getSession.mockImplementation(
+        (id) => (({ A: userA, B: userB }) as Partial<Record<string, User>>)[id],
+      );
+      knockService.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+
+      const clientA = createMockSocket("A");
+      gateway.handleKnockSend(clientA, { targetSocketId: "B" });
+
+      expect(clientA.emit).toHaveBeenCalledWith(
+        "error",
+        expect.objectContaining({ message: expect.stringContaining("이미") }),
+      );
+    });
+  });
+
+  describe("handleUserDisconnecting", () => {
+    it("대화 중 접속 해제 → 파트너에게 to() 호출됨 (TALK_ENDED 전송)", () => {
+      const userB = createUserSession("B", "talking");
+      mockUserService.getSession.mockImplementation((id) => (id === "B" ? userB : undefined));
+      knockService.addTalkingPair("A", "B");
+
+      gateway.handleUserDisconnecting({ clientId: "A", nickname: "UserA" });
+
+      expect(mockServer.to).toHaveBeenCalledWith("B");
+    });
+
+    it("보낸 노크 pending 중 접속 해제 → 수신자에게 to() 호출됨", () => {
+      const userB = createUserSession("B", "available");
+      mockUserService.getSession.mockImplementation((id) => (id === "B" ? userB : undefined));
+      knockService.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+
+      gateway.handleUserDisconnecting({ clientId: "A", nickname: "UserA" });
+
+      expect(mockServer.to).toHaveBeenCalledWith("B");
+    });
+
+    it("받은 노크 pending 중 접속 해제 → 발신자에게 to() 호출됨", () => {
+      mockUserService.getSession.mockReturnValue(undefined);
+      knockService.addPendingKnock({ fromSocketId: "B", fromUserNickname: "B", timestamp: 0 }, "A");
+
+      gateway.handleUserDisconnecting({ clientId: "A", nickname: "UserA" });
+
+      expect(mockServer.to).toHaveBeenCalledWith("B");
+    });
+  });
+});

--- a/apps/server/test/knock/knock.gateway.spec.ts
+++ b/apps/server/test/knock/knock.gateway.spec.ts
@@ -160,22 +160,6 @@ describe("KnockGateway", () => {
     });
   });
 
-  // ===========================================================
-  // [Bug-1] toUser(수락자) 상태 미검증 재현
-  //
-  // knock.gateway.ts:65-148 handleKnockAccept에서
-  // fromUser의 상태(line 87, 96)는 재검증하지만
-  // toUser(client 본인)의 현재 상태는 재검증하지 않음.
-  //
-  // 시나리오:
-  //   t=1: B가 C의 노크를 수락 → B: talking, C: talking
-  //   t=2: B(이미 talking)가 A의 노크도 수락 시도
-  //
-  // 기대: KNOCK_ACCEPT_FAILED (B가 이미 talking)
-  // 실제: 수락 성공 → B-A talkingPair 등록 (B-C 덮어씌워짐)
-  //
-  // → 이 테스트는 버그가 수정될 때까지 실패(FAIL)해야 함
-  // ===========================================================
   describe("[Bug-1] toUser(수락자) 상태 미검증 재현", () => {
     it("[버그 재현] talking 상태인 B가 또 다른 노크를 수락하면 막혀야 하지만 통과됨", () => {
       const userA = createUserSession("A", "available");

--- a/apps/server/test/knock/knock.service.spec.ts
+++ b/apps/server/test/knock/knock.service.spec.ts
@@ -1,0 +1,325 @@
+import { KnockService } from "../../src/knock/knock.service";
+
+describe("KnockService", () => {
+  let service: KnockService;
+
+  beforeEach(() => {
+    service = new KnockService();
+  });
+
+  describe("canKnock", () => {
+    describe("발신자(fromStatus) 상태 검증", () => {
+      it("fromStatus === null → 불가: 데스크존 밖", () => {
+        const result = service.canKnock(null, "available");
+
+        expect(result.canKnock).toBe(false);
+        expect(result.reason).toBe("데스크존에서만 노크할 수 있습니다.");
+      });
+
+      it("fromStatus === focusing → 불가: 집중 중에는 노크 불가", () => {
+        const result = service.canKnock("focusing", "available");
+
+        expect(result.canKnock).toBe(false);
+        expect(result.reason).toContain("보낼 수 없는 상태");
+      });
+
+      it("fromStatus === talking → 불가: 대화 중에는 노크 불가", () => {
+        const result = service.canKnock("talking", "available");
+
+        expect(result.canKnock).toBe(false);
+        expect(result.reason).toContain("보낼 수 없는 상태");
+      });
+    });
+
+    describe("수신자(toStatus) 상태 검증", () => {
+      it("toStatus === null → 불가: 상대가 데스크존 밖", () => {
+        const result = service.canKnock("available", null);
+
+        expect(result.canKnock).toBe(false);
+        expect(result.reason).toContain("상대방이 데스크존에 없습니다.");
+      });
+
+      it("toStatus === focusing → 불가: 상대가 집중 중", () => {
+        const result = service.canKnock("available", "focusing");
+
+        expect(result.canKnock).toBe(false);
+        expect(result.reason).toContain("집중");
+      });
+
+      it("toStatus === talking → 불가: 상대가 대화 중", () => {
+        const result = service.canKnock("available", "talking");
+
+        expect(result.canKnock).toBe(false);
+        expect(result.reason).toContain("대화 중");
+      });
+    });
+
+    describe("정상 케이스", () => {
+      it("both available → 가능", () => {
+        const result = service.canKnock("available", "available");
+
+        expect(result.canKnock).toBe(true);
+        expect(result.reason).toBeUndefined();
+      });
+    });
+
+    describe("발신자 우선 검증 (에러 메시지 우선순위)", () => {
+      it("fromStatus null이면 toStatus가 무엇이든 발신자 오류가 먼저", () => {
+        const result = service.canKnock(null, null);
+
+        expect(result.canKnock).toBe(false);
+        expect(result.reason).toBe("데스크존에서만 노크할 수 있습니다.");
+      });
+
+      it("fromStatus available인데 toStatus null → 수신자 오류 메시지", () => {
+        const result = service.canKnock("available", null);
+
+        expect(result.canKnock).toBe(false);
+        expect(result.reason).toBe("상대방이 데스크존에 없습니다.");
+      });
+    });
+  });
+
+  describe("pendingKnock 생명주기", () => {
+    const makeKnock = (fromId: string) => ({
+      fromSocketId: fromId,
+      fromUserNickname: "TestUser",
+      timestamp: Date.now(),
+    });
+
+    it("addPendingKnock 후 hasPendingKnock true 반환", () => {
+      service.addPendingKnock(makeKnock("A"), "B");
+
+      expect(service.hasPendingKnock("A", "B")).toBe(true);
+    });
+
+    it("노크는 방향성이 있음: A→B와 B→A는 다른 노크", () => {
+      service.addPendingKnock(makeKnock("A"), "B");
+
+      expect(service.hasPendingKnock("A", "B")).toBe(true);
+      expect(service.hasPendingKnock("B", "A")).toBe(false);
+    });
+
+    it("getPendingKnock: 존재하는 노크의 데이터 반환", () => {
+      const knock = makeKnock("A");
+      service.addPendingKnock(knock, "B");
+
+      const result = service.getPendingKnock("A", "B");
+
+      expect(result).toEqual(knock);
+    });
+
+    it("getPendingKnock: 없는 노크는 undefined 반환", () => {
+      expect(service.getPendingKnock("X", "Y")).toBeUndefined();
+    });
+
+    it("removePendingKnock 후 hasPendingKnock false 반환", () => {
+      service.addPendingKnock(makeKnock("A"), "B");
+      service.removePendingKnock("A", "B");
+
+      expect(service.hasPendingKnock("A", "B")).toBe(false);
+    });
+
+    it("없는 노크 remove는 에러 없이 무시", () => {
+      expect(() => service.removePendingKnock("GHOST", "TARGET")).not.toThrow();
+    });
+  });
+
+  describe("removeAllKnocksForUser", () => {
+    it("내가 보낸 노크의 수신자 목록(sentTo)이 정확히 반환됨", () => {
+      service.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+      service.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "C");
+
+      const { sentTo, receivedFrom } = service.removeAllKnocksForUser("A");
+
+      expect(sentTo).toHaveLength(2);
+      expect(sentTo).toContain("B");
+      expect(sentTo).toContain("C");
+      expect(receivedFrom).toHaveLength(0);
+    });
+
+    it("내가 받은 노크의 발신자 목록(receivedFrom)이 정확히 반환됨", () => {
+      service.addPendingKnock({ fromSocketId: "B", fromUserNickname: "B", timestamp: 0 }, "A");
+      service.addPendingKnock({ fromSocketId: "C", fromUserNickname: "C", timestamp: 0 }, "A");
+
+      const { sentTo, receivedFrom } = service.removeAllKnocksForUser("A");
+
+      expect(receivedFrom).toHaveLength(2);
+      expect(receivedFrom).toContain("B");
+      expect(receivedFrom).toContain("C");
+      expect(sentTo).toHaveLength(0);
+    });
+
+    it("보낸 것과 받은 것 혼합 케이스", () => {
+      service.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B"); // A→B (A가 보냄)
+      service.addPendingKnock({ fromSocketId: "C", fromUserNickname: "C", timestamp: 0 }, "A"); // C→A (A가 받음)
+
+      const { sentTo, receivedFrom } = service.removeAllKnocksForUser("A");
+
+      expect(sentTo).toContain("B");
+      expect(receivedFrom).toContain("C");
+    });
+
+    it("정리 후 해당 pendingKnock들이 실제로 삭제됨", () => {
+      service.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+      service.removeAllKnocksForUser("A");
+
+      expect(service.hasPendingKnock("A", "B")).toBe(false);
+    });
+
+    it("관계없는 노크는 삭제되지 않음", () => {
+      service.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+      service.addPendingKnock({ fromSocketId: "X", fromUserNickname: "X", timestamp: 0 }, "Y"); // 무관한 노크
+
+      service.removeAllKnocksForUser("A");
+
+      expect(service.hasPendingKnock("X", "Y")).toBe(true); // 무관한 노크는 유지
+    });
+  });
+
+  describe("[Bug-2] Socket ID 구분자 취약점", () => {
+    it("하이픈 없는 정상 socket ID → removeAllKnocksForUser 정상 작동 (baseline)", () => {
+      service.addPendingKnock({ fromSocketId: "NORMALID", fromUserNickname: "Alice", timestamp: 0 }, "TARGETID");
+
+      const { sentTo } = service.removeAllKnocksForUser("NORMALID");
+
+      expect(sentTo).toContain("TARGETID");
+      expect(service.hasPendingKnock("NORMALID", "TARGETID")).toBe(false);
+    });
+
+    it("[버그 재현] 하이픈이 포함된 from socket ID → removeAllKnocksForUser 실패", () => {
+      const fromSocketIdWithDash = "V0kd-123";
+
+      service.addPendingKnock({ fromSocketId: fromSocketIdWithDash, fromUserNickname: "Bob", timestamp: 0 }, "AAAA");
+
+      const { sentTo } = service.removeAllKnocksForUser(fromSocketIdWithDash);
+
+      expect(sentTo).toContain("AAAA");
+      expect(service.hasPendingKnock(fromSocketIdWithDash, "AAAA")).toBe(false);
+    });
+
+    it("[버그 재현] 하이픈이 포함된 to socket ID → removeAllKnocksForUser 실패", () => {
+      const toSocketIdWithDash = "BBBB-456";
+
+      service.addPendingKnock({ fromSocketId: "CCCC", fromUserNickname: "Charlie", timestamp: 0 }, toSocketIdWithDash);
+
+      const { receivedFrom } = service.removeAllKnocksForUser(toSocketIdWithDash);
+
+      expect(receivedFrom).toContain("CCCC");
+      expect(service.hasPendingKnock("CCCC", toSocketIdWithDash)).toBe(false);
+    });
+
+    it("[버그 수정 검증] | 구분자 사용 시 하이픈 포함 ID도 정상 작동 확인용 (수동 검증)", () => {
+      const fromId = "V0kd-123";
+      const toId = "AAAA-456";
+      const correctKey = `${fromId}|${toId}`;
+
+      const [parsedFrom, parsedTo] = correctKey.split("|");
+
+      expect(parsedFrom).toBe(fromId);
+      expect(parsedTo).toBe(toId);
+    });
+  });
+
+  describe("[설계 결정] TTL 미구현: 정상 종료 경로 전수 검증", () => {
+    it("경로 A: 발신자(A) disconnect 시 A가 보낸 모든 pending knock 즉시 정리", () => {
+      service.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+      service.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "C");
+
+      service.removeAllKnocksForUser("A");
+
+      expect(service.hasPendingKnock("A", "B")).toBe(false);
+      expect(service.hasPendingKnock("A", "C")).toBe(false);
+    });
+
+    it("경로 B: 수신자(B) disconnect 시 B에게 보내진 모든 pending knock 즉시 정리", () => {
+      service.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+      service.addPendingKnock({ fromSocketId: "C", fromUserNickname: "C", timestamp: 0 }, "B");
+
+      service.removeAllKnocksForUser("B");
+
+      expect(service.hasPendingKnock("A", "B")).toBe(false);
+      expect(service.hasPendingKnock("C", "B")).toBe(false);
+    });
+
+    it("경로 A/B 공통: removeAllKnocksForUser는 sent/received 양방향 모두 정리", () => {
+      service.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+      service.addPendingKnock({ fromSocketId: "C", fromUserNickname: "C", timestamp: 0 }, "A");
+
+      const { sentTo, receivedFrom } = service.removeAllKnocksForUser("A");
+
+      expect(sentTo).toContain("B");
+      expect(receivedFrom).toContain("C");
+      expect(service.hasPendingKnock("A", "B")).toBe(false);
+      expect(service.hasPendingKnock("C", "A")).toBe(false);
+    });
+
+    it("[좀비 소켓 잔류 시간 측정] TTL 없이 disconnect 미발생 시 knock은 자동 정리되지 않음", () => {
+      jest.useFakeTimers();
+
+      service.addPendingKnock({ fromSocketId: "A", fromUserNickname: "A", timestamp: 0 }, "B");
+
+      jest.advanceTimersByTime(44_000);
+      expect(service.hasPendingKnock("A", "B")).toBe(true);
+
+      service.removeAllKnocksForUser("A");
+      expect(service.hasPendingKnock("A", "B")).toBe(false);
+
+      jest.useRealTimers();
+    });
+  });
+
+  describe("talkingPair 관리", () => {
+    it("addTalkingPair → 양방향으로 저장됨", () => {
+      service.addTalkingPair("A", "B");
+
+      expect(service.getTalkingPartner("A")).toBe("B");
+      expect(service.getTalkingPartner("B")).toBe("A");
+    });
+
+    it("removeTalkingPair → 파트너 ID 반환", () => {
+      service.addTalkingPair("A", "B");
+
+      const partnerId = service.removeTalkingPair("A");
+
+      expect(partnerId).toBe("B");
+    });
+
+    it("removeTalkingPair → 양쪽 모두 삭제됨", () => {
+      service.addTalkingPair("A", "B");
+      service.removeTalkingPair("A");
+
+      expect(service.getTalkingPartner("A")).toBeUndefined();
+      expect(service.getTalkingPartner("B")).toBeUndefined();
+    });
+
+    it("한쪽(B)이 removeTalkingPair 호출해도 양쪽 삭제됨", () => {
+      service.addTalkingPair("A", "B");
+      service.removeTalkingPair("B");
+
+      expect(service.getTalkingPartner("A")).toBeUndefined();
+      expect(service.getTalkingPartner("B")).toBeUndefined();
+    });
+
+    it("없는 쌍 remove → undefined 반환, 에러 없음", () => {
+      expect(service.removeTalkingPair("GHOST")).toBeUndefined();
+    });
+
+    it("getTalkingPartner: 등록 안된 사용자 → undefined", () => {
+      expect(service.getTalkingPartner("UNKNOWN")).toBeUndefined();
+    });
+
+    it("여러 쌍 독립적으로 관리됨", () => {
+      service.addTalkingPair("A", "B");
+      service.addTalkingPair("C", "D");
+
+      expect(service.getTalkingPartner("A")).toBe("B");
+      expect(service.getTalkingPartner("C")).toBe("D");
+
+      service.removeTalkingPair("A");
+
+      expect(service.getTalkingPartner("A")).toBeUndefined();
+      expect(service.getTalkingPartner("C")).toBe("D");
+    });
+  });
+});


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close #284

<br />

## 📝 작업 내용
### 1. handleKnockAccept 상태 재검증 로직 추가

### (1) 수락자(toUser) 상태 재검증 추가

기존 문제:

- `handleKnockAccept`에서 fromUser 상태는 재검증
- 그러나 toUser(수락자 본인)의 deskStatus는 재검증하지 않음
- talking 상태인 B가 추가 노크를 수락 가능
- → `talkingPairs` 오염
- → 기존 대화 상대(C) 방치되는 이중 세션 버그 발생

수정 내용:

```
if (toUser.deskStatus==="talking") {
client.emit(KNOCK_ACCEPT_FAILED, ...)
return;
}
```

✔ talking 중인 사용자는 추가 수락 불가

✔ 이중 대화 세션 생성 차단

---

### (2) fromUser 상태 실패 시 A에게 KNOCK_CANCELLED emit

기존 문제:

- fromUser가 talking/focusing 상태면
- B는 `KNOCK_ACCEPT_FAILED` 받음
- 하지만 A는 아무 이벤트도 받지 않음
- → 클라이언트 `sentKnockTargets` stale 유지
- → A가 B에게 재노크 불가

수정 내용:

```
this.knockService.removePendingKnock(...)
this.server.to(fromSocketId).emit(KNOCK_CANCELLED)
```

✔ A의 sentKnockTargets 정리

✔ 재노크 가능 상태 복구

---

### 2. KnockService 키 구분자 변경 (- → |)

기존 구현:

```
`${fromSocketId}-${toSocketId}`
```

문제:

- Socket ID는 base64 기반
- `+`가 `-`로 치환될 수 있음
- 실제 socketId에  포함 가능
- `split("-")` 시 잘못 분리
- `removeAllKnocksForUser` 오작동

수정:

```
`${fromSocketId}|${toSocketId}`
```

✔ `|`는 socket ID에 등장하지 않음

✔ 안전한 구분자 사용

### 3. Jest 설정 보강

- `moduleNameMapper` 추가
- `^src/(.*)$` → `<rootDir>/src/$1`
- src 경로 alias 정상 동작

### 4. KnockService 단위 테스트 추가

### 포함 내용

- `canKnock` 상태 조합 4×4 전수 검증
- pendingKnock 생명주기 (add → get → has → remove)
- talkingPair 양방향 저장/삭제
- removeAllKnocksForUser 정확성 검증
- [Bug-2] 하이픈 포함 socket ID 재현 테스트
<img width="600" height="300" alt="스크린샷 2026-03-04 133308" src="https://github.com/user-attachments/assets/e4eb677f-c69c-4602-8c31-3f9682a00e8f" />
<img width="450" height="300" alt="스크린샷 2026-03-04 133526" src="https://github.com/user-attachments/assets/69c75df4-e994-4859-9d79-9b0c977f70fc" />

- TTL 미구현 설계 검증 테스트
    - 정상 종료 경로 전수 확인
    - disconnect 미발생 시 자동 정리 안 됨 확인

### 5. KnockGateway 통합 테스트 추가
handleKnockAccept 핵심 시나리오
- 정상 수락 흐름
- fromUser 상태 검증
- pending knock 미존재
- fromUser undefined
- 교차 노크 정리
- disconnect 시 정리

### [Bug-1] toUser 상태 미검증 재현 테스트 포함

- talking 중인 B가 추가 노크 수락 시
- talkingPairs 오염 발생
- 버그 수정 전까지 FAIL 의도 테스트
<img width="600" height="300" alt="스크린샷 2026-03-04 132753" src="https://github.com/user-attachments/assets/779c7939-8747-424c-89c8-5db92e192b61" />
<img width="450" height="300" alt="스크린샷 2026-03-04 132327" src="https://github.com/user-attachments/assets/69a0c00c-5f3f-4664-9a64-ea9f8c232dfe" />

<br />

## 🫡 참고사항
> 리뷰 예상 시간: `15분`
> [Bug-1, 2] 재현 테스트는 현재 수정 반영 후 PASS 상태입니다
> 기존에 작성해뒀던 내용들을 보완해 데스크존 노크 관련 설계와 정리한 내용은 위키에 업데이트했습니다
> 엣지케이스와 고민과정들이 담겨 있어서 한번씩 읽어보시면 좋을 것 같아요!
> https://github.com/boostcampwm2025/web13-isj-dle/wiki/%EB%85%B8%ED%81%AC-%EC%8B%9C%EC%8A%A4%ED%85%9C-%EC%8B%9C%ED%80%80%EC%8A%A4-%EB%8B%A4%EC%9D%B4%EC%96%B4%EA%B7%B8%EB%9E%A8-%26-%EC%97%A3%EC%A7%80%EC%BC%80%EC%9D%B4%EC%8A%A4
>
> https://github.com/boostcampwm2025/web13-isj-dle/wiki/TTL-%EB%8F%84%EC%9E%85%EC%97%90-%EB%8C%80%ED%95%9C-%EA%B3%A0%EB%AF%BC%EA%B3%BC%EC%A0%95

<br />

## 🤖 AI 활용 경험
- 좀비 소켓 시나리오 및 TTL 설계 검토 과정에서 논리 정리를 보조받아 테스트 가능한 영역 구분
- 테스트 코드 작성
- 상태 조합 전수 검증(DeskStatus 4×4) 테스트 설계 시 AI를 활용해 케이스 누락검토

