### PR TITLE
[Feature] KNOCK_CANCELLED reason 필드 추가 및 토스트 알림 노출 (#288)

### DIFF
--- a/apps/client/src/features/knock/model/use-knock-socket.ts
+++ b/apps/client/src/features/knock/model/use-knock-socket.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import toast from "react-hot-toast";
 
 import { useKnockStore } from "@entities/knock";
 import { useUserStore } from "@entities/user";
@@ -65,6 +66,9 @@ export const useKnockSocket = () => {
       }
       if (payload.targetSocketId) {
         removeSentKnock(payload.targetSocketId);
+      }
+      if (payload.reason && payload.reason !== "talk_started") {
+        toast(payload.reason);
       }
     };
 

--- a/apps/server/src/knock/knock.gateway.ts
+++ b/apps/server/src/knock/knock.gateway.ts
@@ -17,7 +17,7 @@ import { KnockService } from "./knock.service";
 
 @WebSocketGateway()
 export class KnockGateway {
-  @WebSocketServer() server: Server;
+  @WebSocketServer() server!: Server;
   private readonly logger = new Logger(KnockGateway.name);
 
   constructor(
@@ -92,6 +92,7 @@ export class KnockGateway {
       this.knockService.removePendingKnock(payload.fromSocketId, client.id);
       this.server.to(payload.fromSocketId).emit(KnockEventType.KNOCK_CANCELLED, {
         targetSocketId: client.id,
+        reason: "상대방이 현재 대화 중이어서 노크가 취소되었습니다.",
       });
       return;
     }
@@ -104,6 +105,7 @@ export class KnockGateway {
       this.knockService.removePendingKnock(payload.fromSocketId, client.id);
       this.server.to(payload.fromSocketId).emit(KnockEventType.KNOCK_CANCELLED, {
         targetSocketId: client.id,
+        reason: "이미 다른 대화 중이어서 노크가 취소되었습니다.",
       });
       return;
     }
@@ -116,6 +118,7 @@ export class KnockGateway {
       this.knockService.removePendingKnock(payload.fromSocketId, client.id);
       this.server.to(payload.fromSocketId).emit(KnockEventType.KNOCK_CANCELLED, {
         targetSocketId: client.id,
+        reason: "집중 모드로 전환되어 노크가 취소되었습니다.",
       });
       return;
     }
@@ -127,6 +130,7 @@ export class KnockGateway {
       this.knockService.removePendingKnock(client.id, payload.fromSocketId);
       this.server.to(payload.fromSocketId).emit(KnockEventType.KNOCK_CANCELLED, {
         fromSocketId: client.id,
+        reason: "talk_started",
       });
     }
 
@@ -273,11 +277,13 @@ export class KnockGateway {
     for (const targetSocketId of sentTo) {
       this.server.to(targetSocketId).emit(KnockEventType.KNOCK_CANCELLED, {
         fromSocketId: clientId,
+        reason: "상대방 연결이 끊겼습니다.",
       });
     }
     for (const fromSocketId of receivedFrom) {
       this.server.to(fromSocketId).emit(KnockEventType.KNOCK_CANCELLED, {
         targetSocketId: clientId,
+        reason: "상대방 연결이 끊겼습니다.",
       });
     }
   }

--- a/packages/shared/src/knock.types.ts
+++ b/packages/shared/src/knock.types.ts
@@ -54,6 +54,7 @@ export interface Knock {
 export interface KnockCancelledPayload {
   fromSocketId?: string;
   targetSocketId?: string;
+  reason?: string;
 }
 
 export interface KnockAcceptSuccessPayload {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #288

<br />

## 📝 작업 내용

KNOCK_CANCELLED 이벤트 수신 시 UX 개선을 위해 취소 사유(`reason`) 필드를 추가하고, 클라이언트에서 토스트 알림으로 노출하도록 구현했습니다.

**서버**
- `KnockCancelledPayload`에 `reason?: string` 필드 추가
- `KNOCK_CANCELLED` emit 6곳에 취소 사유 메시지 추가
  - 수락자가 대화 중: `"상대방이 현재 대화 중이어서 노크가 취소되었습니다."`
  - 발신자가 대화 중: `"이미 다른 대화 중이어서 노크가 취소되었습니다."`
  - 발신자가 집중 모드로 전환: `"집중 모드로 전환되어 노크가 취소되었습니다."`
  - 교차 노크 정리: `"talk_started"` (클라이언트에서 토스트 skip용 코드값)
  - disconnect: `"상대방 연결이 끊겼습니다."`
- @WebSocketServer() 데코레이터로 런타임에 주입되는 필드를 TypeScript가 "초기값 없음"으로 인식해 ts 에러가 발생해 '!' 추가.

**클라이언트**
- `handleKnockCancelled`에서 `reason`이 있고 `"talk_started"`가 아닐 때 토스트 알림 노출
- 교차 노크 케이스(`"talk_started"`)는 `KNOCK_ACCEPTED`와 거의 동시에 수신되어 혼란을 줄 수 있어 토스트를 띄우지 않음

<br />

## 🫡 참고사항
> 리뷰 예상 시간: `3분`

교차 노크 케이스에서 `reason: "talk_started"` 코드값을 사용한 이유:
A→B, B→A 노크가 동시에 존재할 때 B가 A의 노크를 수락하면, A는 `KNOCK_ACCEPTED`와 `KNOCK_CANCELLED`를 거의 동시에 수신합니다. 이미 대화가 시작된 상태에서 취소 토스트가 뜨면 UX상 혼란스럽기 때문에, 이 케이스만 별도 코드값으로 구분해 토스트를 skip하도록 처리했습니다.

<br />

## 🤖 AI 활용 경험
Claude Code를 활용해 reason 메시지의 수신자 관점 적절성 검토 
