### PR TITLE
[Fix] 코드 에디터 Y.Text 메모리 누수 및 초기화 로직 개선 (#290)

### DIFF
--- a/apps/client/src/features/code-editor-sidebar/model/use-editor-binding.ts
+++ b/apps/client/src/features/code-editor-sidebar/model/use-editor-binding.ts
@@ -53,7 +53,9 @@ export const useEditorBinding = (
       bindingRef.current = null;
     }
 
-    const ytext = ydocRef.current.getText(`file-${selectedFileId}`);
+    const filesContent = ydocRef.current.getMap<Y.Text>("files-content");
+    const ytext = filesContent.get(selectedFileId);
+    if (!ytext) return;
     ytextRef.current = ytext;
     const uri = monaco.Uri.parse(`file:///${selectedFileId}`);
 

--- a/apps/client/src/features/code-editor-sidebar/model/use-file-system.ts
+++ b/apps/client/src/features/code-editor-sidebar/model/use-file-system.ts
@@ -8,7 +8,7 @@ import {
 } from "./code-editor.constants";
 import { type FileSystemItem, getLanguageFromFileName } from "./file-explorer.utils";
 import type * as Monaco from "monaco-editor";
-import type * as Y from "yjs";
+import * as Y from "yjs";
 
 export const useFileSystem = (
   ydocRef: RefObject<Y.Doc | null>,
@@ -74,7 +74,13 @@ export const useFileSystem = (
 
       const id = crypto.randomUUID();
       const item: FileSystemItem = { id, name: finalName, type, parentId };
-      fsMap.set(id, item);
+      ydocRef.current.transact(() => {
+        fsMap.set(id, item);
+        if (type === "file") {
+          const filesContent = ydocRef.current!.getMap<Y.Text>("files-content");
+          filesContent.set(id, new Y.Text());
+        }
+      });
     },
     [monaco, ydocRef],
   );
@@ -96,8 +102,16 @@ export const useFileSystem = (
           });
         }
 
+        const ydoc = ydocRef.current!;
+        ydoc.transact(() => {
+          const filesContent = ydoc.getMap<Y.Text>("files-content");
+          toDelete.forEach((id) => {
+            filesContent.delete(id);
+            fsMap.delete(id);
+          });
+        });
+
         toDelete.forEach((id) => {
-          fsMap.delete(id);
           if (selectedFileId === id) {
             selectFile(null);
           }

--- a/apps/client/src/features/code-editor-sidebar/model/use-yjs.ts
+++ b/apps/client/src/features/code-editor-sidebar/model/use-yjs.ts
@@ -44,7 +44,11 @@ export const useYjs = (roomId: string) => {
     };
 
     provider.on("status", handleStatus);
-    setTimeout(() => setIsInitialized(true), 0);
+    const fallback = setTimeout(() => setIsInitialized(true), 3000);
+    provider.once("sync", () => {
+      clearTimeout(fallback);
+      setIsInitialized(true);
+    });
 
     return () => {
       provider.off("status", handleStatus);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close #290

<br />

## 📝 작업 내용

### 문제 1 — Y.Text 메모리 누수 개선

**원인**

`ydoc.getText(`file-${id}`)` 로 생성된 Y.Text는 `ydoc.share`에 named root type으로 등록.
named root type은 삭제 API가 존재하지 않아 파일 삭제 후에도 영구 잔류하며,
파일 생성/삭제가 반복될수록 문서 크기와 메모리가 단방향으로 누적.

**변경 내용**

`files-content` Y.Map 안에 Y.Text를 중첩 관리하는 방식으로 변경해 `filesContent.delete(id)` 로 제거 가능하게 했습니다.

- `use-file-system`: 파일 생성 시 `filesContent`에 Y.Text 등록, 삭제 시 제거. `fsMap`과 함께 `transact()`로 원자적 처리
- `use-editor-binding`: Y.Text 조회를 `ydoc.getText()`에서 `filesContent.get()`으로 변경, null check 추가

**측정 결과** (파일 10개 생성/삭제 5사이클 반복 기준)

| | 기존 | 변경 |
|---|---|---|
| `ydoc.share` count | 51 (사이클마다 10씩 증가) | **2 고정** |
| 문서 크기 | 30,081 bytes | **5,470 bytes** |

---

### 문제 2 — setTimeout(0) 초기화 로직 개선

기존 `setTimeout(0)`은 서버 동기화 완료와 무관하게 에디터를 열어 우연히 동작하는 코드였습니다.
`provider.once('sync')`로 실제 동기화 완료 시점에 에디터를 열도록 변경하고, sync 이벤트가 오지 않는 경우를 대비해 3초 fallback을 추가했습니다.

<br />

## 🫡 참고사항
리뷰 예상 시간: `10분`

- `use-editor-binding`에서 `filesContent.get()`이 undefined를 반환하는 경우(폴더 선택 등) null check로 조기 반환 처리
- `fsMap`과 `filesContent`를 `transact()`로 묶어 둘 중 하나만 적용되는 상황 방지
- CRDT 특성상 Y.Map 삭제도 tombstone으로 기록되어 문서 크기가 완전히 0으로 돌아가지는 않으나, named type 누적 문제는 해결됨
- 문제 3(동시 파일 생성 중복 이름 체크)은 실제 UI 환경에서 재현 불가능 수준으로 생각해 적용하지 않았는데, 혹 다른 생각이 있으시다면 편하게 말씀해주세요!
- 관련 정리 문서 위키 :[ Yjs 문서 크기 비선형 증가와 GC 조건 심층 분석](https://github.com/boostcampwm2025/web13-isj-dle/wiki/Yjs-%EB%AC%B8%EC%84%9C-%ED%81%AC%EA%B8%B0-%EB%B9%84%EC%84%A0%ED%98%95-%EC%A6%9D%EA%B0%80%EC%99%80-GC-%EC%A1%B0%EA%B1%B4-%EC%8B%AC%EC%B8%B5-%EB%B6%84%EC%84%9D), [메모리 누수와 동시성 문제](https://github.com/boostcampwm2025/web13-isj-dle/wiki/Yjs-%EC%8B%A4%EC%8B%9C%EA%B0%84-%EC%BD%94%EB%93%9C-%EC%97%90%EB%94%94%ED%84%B0-%EA%B8%B0%EC%88%A0-%EB%B6%84%EC%84%9D%3A-%EB%A9%94%EB%AA%A8%EB%A6%AC-%EB%88%84%EC%88%98%EC%99%80-%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C)
<br />

## 🤖 AI 활용 경험
Claude Code를 활용해 Y.Map 중첩 구조로의 변경 방향을 검토하고, 변경 전후 코드의 일관성 및 누락된 케이스(폴더 삭제 시 filesContent 처리 등)를 점검했습니다.
